### PR TITLE
Set components in the config components section and fix build tools version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ android:
     - tools
     - tools # https://github.com/travis-ci/travis-ci/issues/6040#issuecomment-219367943
     - platform-tools
+    # The SDK version used to compile your project
+    - android-23
     
   licenses:
     - 'android-sdk-license-.+'
@@ -13,9 +15,6 @@ android:
 
     # The BuildTools version used by your project
     - build-tools-24.0.2
-
-    # The SDK version used to compile your project
-    - android-23
 
     # Additional components
     # - extra-google-google_play_services

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ android:
     - platform-tools
     # The SDK version used to compile your project
     - android-23
-    
-  licenses:
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
-
     # The BuildTools version used by your project
     - build-tools-24.0.2
 
@@ -26,6 +21,7 @@ android:
     # if you need to run emulator(s) during your tests
     # - sys-img-armeabi-v7a-android-19
     # - sys-img-x86-android-17
+
 jdk:
     - oraclejdk8
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     # The SDK version used to compile your project
     - android-23
     # The BuildTools version used by your project
-    - build-tools-24.0.2
+    - build-tools-23.0.2
 
     # Additional components
     # - extra-google-google_play_services


### PR DESCRIPTION
Hey there! :-)

It looks like there were some `components` being specified in the `licenses` section instead.

I just moved these extra components to the `components` section. I deleted the `licenses` section too. This is not required, but Travis CI accepts all licenses by default so it is not necessary to add them explicitly.

This PR also edits the build tools version from 24.0.2 to 23.0.2, as it seemed to be required by the project.